### PR TITLE
Feat(register, artist, detail): show artists’ published links; rename Save→Submit; remove Import/Export; fix Register nav

### DIFF
--- a/src/cycle2/about.html
+++ b/src/cycle2/about.html
@@ -30,7 +30,7 @@
               <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
               <li><a href="search.html" class="nav-link">Search</a></li>
               <li><a href="about.html" class="nav-link nav-active">About Us</a></li>
-              <li><a href="#" class="nav-link nav-disabled" title="Coming soon">Register</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
             </ul>
             <div class="user-avatar">
               <div class="avatar-container">

--- a/src/cycle2/artist.html
+++ b/src/cycle2/artist.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Artist Page — Indigenous Art Atlas</title>
+    <link rel="stylesheet" href="homePage/styles.css" />
+    <style>
+      .hero { padding: var(--space-3xl) 0; background: var(--elev-1); border-bottom: 1px solid var(--elev-2); }
+      .hero h1 { margin-bottom: var(--space-sm); }
+      .hero p  { color: var(--muted); }
+      .dash { padding: var(--space-3xl) 0; }
+      .card { background: var(--elev-1); border:1px solid var(--elev-2); border-radius: var(--border-radius-lg); 
+              box-shadow: var(--shadow-md); overflow:hidden; }
+      .card-body { padding: var(--space-xl); }
+      .grid { display:grid; grid-template-columns: 220px 1fr; gap: var(--space-xl); }
+      .avatar { width: 220px; height: 220px; object-fit: cover; border-radius: var(--border-radius-lg); border:1px solid var(--elev-2); }
+      .meta p { margin:6px 0; }
+      .tags .tag{ display:inline-block; padding:2px 8px; margin-right:8px; margin-bottom:8px; background:var(--elev-2); 
+                  border-radius:var(--border-radius); color:var(--muted); font-size: var(--font-size-sm); }
+      .status-badge{display:inline-block;padding:2px 8px;border-radius:var(--border-radius);font-size:var(--font-size-sm);
+        border:1px solid var(--elev-2);margin-left:6px}
+      .status-pending{color:#f0c674;border-color:#f0c67433;background:transparent}
+      .status-approved{color:#8dc891;border-color:#8dc89133;background:transparent}
+      .toolbar{ display:flex; flex-wrap:wrap; gap: var(--space-md); margin-top: var(--space-md); }
+      .section{ margin-top: var(--space-xl); }
+      .list a{ display:inline-block; margin-right:10px; margin-bottom:8px; }
+      .chooser{ margin: var(--space-xl) 0; display:flex; gap: var(--space-md); align-items: center; }
+      .select{ padding:var(--space-sm) var(--space-md); background:var(--elev-2); border:1px solid var(--accent); color:var(--text); border-radius:var(--border-radius); }
+      @media (max-width: 900px){ .grid { grid-template-columns:1fr; } .avatar{ width:100%; height: auto; max-height: 280px; } }
+    </style>
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+
+    <header class="header" role="banner">
+      <div class="container">
+        <div class="header-content">
+          <div class="logo">
+            <a href="homePage/index.html" class="logo-link"><h1 class="logo-text">Indigenous Art Atlas</h1></a>
+          </div>
+          <nav class="nav" role="navigation" aria-label="Main navigation">
+            <ul class="nav-list">
+              <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
+              <li><a href="search.html" class="nav-link">Search</a></li>
+              <li><a href="about.html" class="nav-link">About Us</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
+            </ul>
+            <div class="user-avatar">
+              <div class="avatar-container">
+                <img src="assets/img/user-avatar.png" alt="User avatar" class="avatar-image"
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                <div class="avatar-fallback"><span class="avatar-initials">JD</span></div>
+                <span class="user-name">John Doe</span>
+              </div>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="hero">
+        <div class="container">
+          <h1 class="page-title">Artist Page</h1>
+          <p class="page-description">View your profile and the links to your published artworks.</p>
+
+          <div class="chooser" id="chooser">
+            <label for="artistNameInput" class="label">Find artist by name:</label>
+            <input id="artistNameInput" class="select" list="artistNameList" placeholder="Type full name (e.g., Vincent Namatjira)"/>
+            <datalist id="artistNameList"></datalist>
+            <button class="btn btn-secondary" id="findBtn">Find</button>
+            <button class="btn btn-secondary" id="shareBtn" title="Copy shareable link">Copy Share Link</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="dash">
+        <div class="container">
+          <div class="card" id="artistCard" style="display:none">
+            <div class="card-body">
+              <div class="grid">
+                <img id="pImg" class="avatar" src="" alt="Artist image">
+                <div>
+                  <h2 id="pName" class="section-title" style="margin-top:0"></h2>
+                  <div class="meta">
+                    <p><strong>Role:</strong> <span id="pRole"></span> <span id="pStatus" class="status-badge"></span></p>
+                    <p id="pEmail"></p>
+                    <div class="tags" id="pTags"></div>
+                  </div>
+
+                  <div class="toolbar">
+                    <a class="btn btn-secondary" href="register.html">Edit My Account</a>
+                    <a class="btn btn-secondary" href="artwork-submit.html" id="submitBtn">Submit Artwork</a>
+                  </div>
+
+                  <div class="section">
+                    <h3 class="section-title">Published Artworks</h3>
+                    <div id="artLinks" class="list"></div>
+                    <p id="noArt" class="page-description" style="display:none">No published artworks yet.</p>
+                    <div style="margin-top: var(--space-md);">
+                      <a class="btn btn-primary" id="viewDetailsBtn" href="#">View your artwork details</a>
+                    </div>
+                  </div>
+
+                  <div class="section" id="bioSec" style="display:none">
+                    <h3 class="section-title">Bio</h3>
+                    <p id="pBio" class="page-description"></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p id="emptyNote" class="page-description" style="display:none">No artist accounts found. Please create one on the Register page.</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer" role="contentinfo">
+      <div class="container">
+        <div class="footer-bottom">
+          <p class="footer-copyright">© Indigenous Art Atlas</p>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const STORE_KEY = "IAA_accounts_v1";
+      const artistNameInput = document.getElementById("artistNameInput");
+      const chooser = document.getElementById("chooser");
+      const artistCard = document.getElementById("artistCard");
+      const emptyNote = document.getElementById("emptyNote");
+      const submitBtn = document.getElementById("submitBtn");
+      const viewDetailsBtn = document.getElementById("viewDetailsBtn");
+      const findBtn = document.getElementById("findBtn");
+
+      const pImg = document.getElementById("pImg");
+      const pName = document.getElementById("pName");
+      const pRole = document.getElementById("pRole");
+      const pStatus = document.getElementById("pStatus");
+      const pEmail = document.getElementById("pEmail");
+      const pTags = document.getElementById("pTags");
+      const pBio = document.getElementById("pBio");
+      const bioSec = document.getElementById("bioSec");
+      const artLinks = document.getElementById("artLinks");
+      const noArt = document.getElementById("noArt");
+
+      function loadAccounts(){
+        try { return JSON.parse(localStorage.getItem(STORE_KEY)) || []; } catch { return []; }
+      }
+      function getParam(name){
+        const u = new URL(window.location.href);
+        return u.searchParams.get(name);
+      }
+      function escapeHtml(str){
+        return String(str || '').replace(/[&<>"']/g, s => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;'}[s]));
+      }
+
+      const all = loadAccounts().filter(a => a.role === "artist");
+      // Build datalist suggestions
+      const nameList = document.getElementById("artistNameList");
+      if (!all.length){
+        emptyNote.style.display = "block";
+        chooser.style.display = "none";
+      } else {
+        nameList.innerHTML = all.map(a=>`<option value="${a.name}"></option>`).join("");
+      }
+
+      // Find artist by name (case-insensitive). Prefer exact match; otherwise first partial match.
+      function findByName(name){
+        if (!name) return null;
+        const norm = name.trim().toLowerCase();
+        let hit = all.find(a => (a.name||'').toLowerCase() === norm);
+        if (!hit) hit = all.find(a => (a.name||'').toLowerCase().includes(norm));
+        return hit || null;
+      }
+
+      if (!all.length){
+        emptyNote.style.display = "block";
+        chooser.style.display = "none";
+      } else {
+        artistSelect.innerHTML = all.map(a=>`<option value="${a.id}">${a.name} (${a.email || 'no-email'})</option>`).join("");
+      }
+
+      function showArtist(id){
+        const a = all.find(x => x.id === id) || all[0];
+        if (!a){ return; }
+        artistCard.style.display = "block";
+        pImg.src = a.imageUrl || "assets/img/user-avatar.png";
+        pImg.onerror = () => { pImg.src = "assets/img/user-avatar.png"; };
+        pName.textContent = a.name || "Artist";
+        pRole.textContent = (a.role||'artist').toUpperCase();
+        const sClass = a.status === "approved" ? "status-approved" : "status-pending";
+        pStatus.className = "status-badge " + sClass;
+        pStatus.textContent = a.status === "approved" ? "Approved" : "Pending Approval";
+        pEmail.innerHTML = a.email ? `<strong>Email:</strong> ${escapeHtml(a.email)}` : "";
+        pTags.innerHTML = "";
+        if (a.region) pTags.innerHTML += `<span class="tag">${escapeHtml(a.region)}</span>`;
+        if (a.nation) pTags.innerHTML += `<span class="tag">${escapeHtml(a.nation)}</span>`;
+
+        if (a.bio){ bioSec.style.display="block"; pBio.textContent = a.bio; } else { bioSec.style.display="none"; }
+
+        artLinks.innerHTML = "";
+        if (Array.isArray(a.artworks) && a.artworks.length){
+          a.artworks.forEach(u => {
+            const link = document.createElement('a');
+            link.className = 'footer-link';
+            link.href = u;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.textContent = 'Artwork';
+            artLinks.appendChild(link);
+          });
+          noArt.style.display = "none";
+        }else{
+          noArt.style.display = "block";
+        }
+
+        // enable submit only if approved
+        const eligible = a.status === "approved";
+        submitBtn.classList.toggle("btn-disabled", !eligible);
+        submitBtn.setAttribute("aria-disabled", String(!eligible));
+
+        // build deep-link to auto view artwork details on search page
+        const artistParam = encodeURIComponent(a.name || '');
+        viewDetailsBtn.href = `search.html?artist=${artistParam}&autoview=1`;
+      }
+
+      // open button
+      findBtn.addEventListener("click", () => {
+        const name = artistNameInput.value;
+        const hit = findByName(name);
+        if (!hit){ alert("Artist not found."); return; }
+        showArtist(hit.id);
+        const u = new URL(window.location.href);
+        u.searchParams.set("id", hit.id);
+        u.searchParams.set("name", encodeURIComponent(hit.name||""));
+        history.replaceState(null, "", u.toString());
+      });
+
+      // share link
+      document.getElementById("shareBtn").addEventListener("click", () => {
+        const u = new URL(window.location.href);
+        const n = artistNameInput.value || "";
+        const hit = findByName(n);
+        if (hit) {
+          u.searchParams.set("id", hit.id);
+          u.searchParams.set("name", encodeURIComponent(hit.name||""));
+        }
+        navigator.clipboard.writeText(u.toString()).then(()=>{
+          alert('Link copied!');
+        }, ()=>{ alert('Copy failed.'); });
+      });
+
+      // Auto open by query param
+      const qid = getParam("id");
+      const qname = getParam("name");
+      if (qid){ showArtist(qid); }
+      else if (qname){ const hit = findByName(decodeURIComponent(qname)); if (hit) { artistNameInput.value = hit.name; showArtist(hit.id); } }
+    </script>
+  </body>
+</html>

--- a/src/cycle2/artwork-submit.html
+++ b/src/cycle2/artwork-submit.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Artwork Information Submission</title>
+    <link rel="stylesheet" href="homePage/styles.css" />
+    <style>
+      .form-section{padding:var(--space-3xl) 0;background:var(--elev-1);border-bottom:1px solid var(--elev-2)}
+      .form-card{max-width:960px;margin:0 auto;background:var(--elev-1);border:1px solid var(--elev-2);
+        border-radius:var(--border-radius-lg);box-shadow:var(--shadow-md);padding:var(--space-xl)}
+      .form-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-lg)}
+      .form-row{display:flex;flex-direction:column;gap:var(--space-xs)}
+      .form-row.full{grid-column:1 / -1}
+      .label{font-size:var(--font-size-sm);color:var(--muted)}
+      .input,.select,.textarea{padding:var(--space-sm) var(--space-md);background:var(--elev-2);border:1px solid var(--accent);
+        border-radius:var(--border-radius);color:var(--text);transition:border-color var(--transition-fast)}
+      .textarea{min-height:140px;resize:vertical}
+      .input:focus,.select:focus,.textarea:focus{border-color:var(--focus);outline:none}
+      .form-actions{display:flex;gap:var(--space-md);margin-top:var(--space-lg)}
+      .hint{color:var(--muted);font-size:var(--font-size-sm)}
+      .disabled-note{color:var(--muted);font-size:var(--font-size-sm);margin-top:4px}
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <header class="header" role="banner">
+      <div class="container">
+        <div class="header-content">
+          <div class="logo">
+            <a href="homePage/index.html" class="logo-link"><h1 class="logo-text">Indigenous Art Atlas</h1></a>
+          </div>
+          <nav class="nav" role="navigation" aria-label="Main navigation">
+            <ul class="nav-list">
+              <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
+              <li><a href="search.html" class="nav-link">Search</a></li>
+              <li><a href="about.html" class="nav-link">About Us</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
+            </ul>
+            <div class="user-avatar">
+              <div class="avatar-container">
+                <img src="assets/img/user-avatar.png" alt="User avatar" class="avatar-image"
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                <div class="avatar-fallback"><span class="avatar-initials">JD</span></div>
+                <span class="user-name">John Doe</span>
+              </div>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="main-content" role="main">
+      <section class="search-header">
+        <div class="container">
+          <h1 class="page-title">Artwork Information Submission</h1>
+          <p class="page-description">Only <strong>approved artists</strong> can submit artworks. Submissions are reviewed by admins before publication.</p>
+        </div>
+      </section>
+
+      <section class="form-section">
+        <div class="container">
+          <div class="form-card">
+            <form id="artwork-form" novalidate>
+              <div class="form-grid">
+                <div class="form-row">
+                  <label class="label" for="title">Title *</label>
+                  <input id="title" class="input" type="text" required placeholder="e.g., Caring for Country" />
+                </div>
+                <div class="form-row">
+                  <label class="label" for="artist">Artist *</label>
+                  <input id="artist" class="input" type="text" required placeholder="e.g., Vincent Namatjira" />
+                </div>
+
+                <div class="form-row">
+                  <label class="label" for="artType">Art Type *</label>
+                  <select id="artType" class="select" required>
+                    <option value="Portrait">Portrait</option>
+                    <option value="Painting">Painting</option>
+                    <option value="Installation">Installation</option>
+                    <option value="Sound Installation">Sound Installation</option>
+                    <option value="Glass Installation">Glass Installation</option>
+                    <option value="Cave Art">Cave Art</option>
+                    <option value="Mural">Mural</option>
+                    <option value="Gallery Piece">Gallery Piece</option>
+                    <option value="Rock Painting">Rock Painting</option>
+                    <option value="Sculpture">Sculpture</option>
+                  </select>
+                </div>
+
+                <div class="form-row">
+                  <label class="label" for="period">Period *</label>
+                  <select id="period" class="select" required>
+                    <option value="Ancient">Ancient</option>
+                    <option value="Contemporary">Contemporary</option>
+                  </select>
+                </div>
+
+                <div class="form-row">
+                  <label class="label" for="region">Region *</label>
+                  <select id="region" class="select" required>
+                    <option value="NSW">NSW</option><option value="VIC">VIC</option>
+                    <option value="QLD">QLD</option><option value="SA">SA</option>
+                    <option value="WA">WA</option><option value="NT">NT</option>
+                    <option value="TAS">TAS</option><option value="ACT">ACT</option>
+                  </select>
+                </div>
+
+                <div class="form-row">
+                  <label class="label" for="sensitive">Sensitive *</label>
+                  <select id="sensitive" class="select" required>
+                    <option value="false" selected>false</option>
+                    <option value="true">true</option>
+                  </select>
+                  <p class="hint">If <strong>true</strong>, the address must not be provided.</p>
+                </div>
+
+                <div class="form-row full">
+                  <label class="label" for="address">Address (optional)</label>
+                  <input id="address" class="input" type="text" placeholder="e.g., 123 King William St, Adelaide SA"/>
+                  <p class="disabled-note" id="address-note" style="display:none;">Address disabled because the artwork is marked as sensitive.</p>
+                </div>
+
+                <div class="form-row full">
+                  <label class="label" for="artworkImage">Artwork Image (optional)</label>
+                  <input id="artworkImage" class="input" type="url" placeholder="https://.../image2.jpg" />
+                </div>
+
+                <div class="form-row full">
+                  <label class="label" for="desc">Description</label>
+                  <textarea id="desc" class="textarea" placeholder="Context, story, permissions, etc."></textarea>
+                </div>
+              </div>
+
+              <div class="form-actions">
+                <button class="btn btn-primary" type="submit">Submit</button>
+                <a class="btn btn-secondary" href="register.html">Back to Register</a>
+              </div>
+            </form>
+            <p id="submit-note" class="page-description" style="margin-top:var(--space-md);display:none;"></p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer" role="contentinfo">
+      <div class="container">
+        <div class="footer-bottom">
+          <p class="footer-copyright">© Indigenous Art Atlas</p>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const form = document.getElementById('artwork-form');
+      const note = document.getElementById('submit-note');
+      const sensitiveSel = document.getElementById('sensitive');
+      const addressInput = document.getElementById('address');
+      const addressNote = document.getElementById('address-note');
+      const artworkImageInput = document.getElementById('artworkImage');
+
+      function updateAddressState() {
+        const isSensitive = sensitiveSel.value === 'true';
+        addressInput.disabled = isSensitive;
+        addressNote.style.display = isSensitive ? 'block' : 'none';
+        if (isSensitive) addressInput.value = '';
+      }
+      sensitiveSel.addEventListener('change', updateAddressState);
+      document.addEventListener('DOMContentLoaded', updateAddressState);
+
+      function isValidUrl(v){ try { new URL(v); return true; } catch { return false; } }
+      function setValidity(el, ok, msg){
+        el.setCustomValidity(ok ? '' : msg);
+        if (!ok) el.reportValidity();
+      }
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+
+        const title = document.getElementById('title').value.trim();
+        const artist = document.getElementById('artist').value.trim();
+        const artType = document.getElementById('artType').value;
+        const period = document.getElementById('period').value;
+        const region = document.getElementById('region').value;
+        const sensitive = sensitiveSel.value === 'true';
+        const address = addressInput.value.trim();
+        const desc = document.getElementById('desc').value.trim();
+        const artworkImage = artworkImageInput.value.trim();
+
+        if (!title){ setValidity(document.getElementById('title'), false, 'Please enter the title.'); return; }
+        if (!artist){ setValidity(document.getElementById('artist'), false, 'Please enter the artist.'); return; }
+        setValidity(document.getElementById('title'), true, '');
+        setValidity(document.getElementById('artist'), true, '');
+
+        if (sensitive && address){
+          setValidity(addressInput, false, 'Address cannot be provided when sensitive is true.'); 
+          return;
+        } else {
+          setValidity(addressInput, true, '');
+        }
+
+        if (artworkImage && !isValidUrl(artworkImage)) {
+          setValidity(artworkImageInput, false, 'Inappropriate URL format!');
+          return;
+        } else {
+          setValidity(artworkImageInput, true, '');
+        }
+
+        const data = {
+          id: 'w_' + Math.random().toString(36).slice(2) + Date.now().toString(36),
+          title, artist, artType, period, region,
+          sensitive, address: address || null,
+          artworkImage: artworkImage || null,
+          description: desc,
+          status: 'pending'
+        };
+        const key = 'IAA_artwork_submissions_v1';
+        const arr = JSON.parse(localStorage.getItem(key) || '[]');
+        arr.push(data);
+        localStorage.setItem(key, JSON.stringify(arr));
+
+        note.style.display = 'block';
+        note.textContent = 'Submitted! Your artwork is pending admin review.';
+        form.reset();
+        updateAddressState();
+      });
+    </script>
+  </body>
+</html>

--- a/src/cycle2/detail.html
+++ b/src/cycle2/detail.html
@@ -30,7 +30,7 @@
               <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
               <li><a href="search.html" class="nav-link">Search</a></li>
               <li><a href="about.html" class="nav-link">About Us</a></li>
-              <li><a href="#" class="nav-link nav-disabled" title="Coming soon">Register</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
             </ul>
             <div class="user-avatar">
               <div class="avatar-container">

--- a/src/cycle2/guidelines.html
+++ b/src/cycle2/guidelines.html
@@ -30,7 +30,7 @@
               <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
               <li><a href="search.html" class="nav-link">Search</a></li>
               <li><a href="about.html" class="nav-link">About Us</a></li>
-              <li><a href="#" class="nav-link nav-disabled" title="Coming soon">Register</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
             </ul>
             <div class="user-avatar">
               <div class="avatar-container">

--- a/src/cycle2/homePage/index.html
+++ b/src/cycle2/homePage/index.html
@@ -34,7 +34,7 @@
             <li><a href="#map-section" class="nav-link">Map</a></li>
             <li><a href="../search.html" class="nav-link">Search</a></li>
             <li><a href="../about.html" class="nav-link">About Us</a></li>
-            <li><a href="#" class="nav-link nav-disabled" title="Coming soon">Register</a></li>
+            <li><a href="../register.html" class="nav-link">Register</a></li>
           </ul>
           <div class="user-avatar">
             <div class="avatar-container">

--- a/src/cycle2/register.html
+++ b/src/cycle2/register.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Register — Indigenous Art Atlas</title>
+    <meta name="description" content="Register a user or artist account. Admin approves accounts and artworks before public display."/>
+    <link rel="stylesheet" href="homePage/styles.css" />
+    <style>
+      .form-section{padding:var(--space-3xl) 0;background:var(--elev-1);border-bottom:1px solid var(--elev-2)}
+      .form-card{max-width:900px;margin:0 auto;background:var(--elev-1);border:1px solid var(--elev-2);
+        border-radius:var(--border-radius-lg);box-shadow:var(--shadow-md);padding:var(--space-xl)}
+      .form-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-lg)}
+      .form-row{display:flex;flex-direction:column;gap:var(--space-xs)}
+      .form-row.full{grid-column:1 / -1}
+      .label{font-size:var(--font-size-sm);color:var(--muted)}
+      .input,.select,.textarea{padding:var(--space-sm) var(--space-md);background:var(--elev-2);border:1px solid var(--accent);
+        border-radius:var(--border-radius);color:var(--text);transition:border-color var(--transition-fast)}
+      .textarea{min-height:120px;resize:vertical}
+      .input:focus,.select:focus,.textarea:focus{border-color:var(--focus);outline:none}
+      .form-actions{display:flex;gap:var(--space-md);margin-top:var(--space-lg);flex-wrap:wrap}
+      .list-section{padding:var(--space-3xl) 0}
+      .list-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:var(--space-xl)}
+      .artist-card{background:var(--elev-1);border:1px solid var(--elev-2);border-radius:var(--border-radius-lg);
+        overflow:hidden;transition:all var(--transition-base)}
+      .artist-card:hover{transform:scale(1.01);box-shadow:var(--shadow-lg);border-color:var(--accent)}
+      .artist-cover{width:100%;aspect-ratio:4/3;object-fit:cover;border-bottom:1px solid var(--elev-2)}
+      .artist-content{padding:var(--space-lg)}
+      .artist-title{font-size:var(--font-size-lg);font-weight:600;margin-bottom:var(--space-xs)}
+      .artist-sub{color:var(--muted);margin-bottom:var(--space-sm)}
+      .tag{display:inline-block;padding:2px 8px;background:var(--elev-2);color:var(--muted);border-radius:var(--border-radius);
+        font-size:var(--font-size-sm);margin-right:6px;margin-bottom:6px}
+      .status-badge{display:inline-block;padding:2px 8px;border-radius:var(--border-radius);font-size:var(--font-size-sm);border:1px solid var(--elev-2);margin-left:6px}
+      .status-pending{color:#f0c674;border-color:#f0c67433;background:transparent}
+      .status-approved{color:#8dc891;border-color:#8dc89133;background:transparent}
+      .links-list a{display:inline-block;margin-right:10px;margin-bottom:8px}
+      dialog{border:none;border-radius:var(--border-radius-lg);background:var(--elev-1);color:var(--text);
+        padding:var(--space-xl);width:min(720px,90vw)}
+      dialog::backdrop{background:rgba(0,0,0,.6)}
+      @media(max-width:900px){.form-grid{grid-template-columns:1fr}}
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+
+    <header class="header" role="banner">
+      <div class="container">
+        <div class="header-content">
+          <div class="logo">
+            <a href="homePage/index.html" class="logo-link"><h1 class="logo-text">Indigenous Art Atlas</h1></a>
+          </div>
+          <nav class="nav" role="navigation" aria-label="Main navigation">
+            <ul class="nav-list">
+              <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
+              <li><a href="search.html" class="nav-link">Search</a></li>
+              <li><a href="about.html" class="nav-link">About Us</a></li>
+              <li><a href="register.html" class="nav-link nav-active">Register</a></li>
+            </ul>
+            <div class="user-avatar">
+              <div class="avatar-container">
+                <img src="assets/img/user-avatar.png" alt="User avatar" class="avatar-image"
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                <div class="avatar-fallback"><span class="avatar-initials">JD</span></div>
+                <span class="user-name">John Doe</span>
+              </div>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main id="main-content" role="main">
+      <section class="search-header">
+        <div class="container">
+          <h1 class="page-title">Account Registration</h1>
+          <p class="page-description">Register as a <strong>user</strong> or an <strong>artist</strong>. Your account must be approved by an admin before you can submit artworks. Approved artworks will be displayed on the site.</p>
+          <p class="page-description" style="margin-top: var(--space-md)">
+            If you are an already-registered artist, click this button to visit your artist page
+            <a class="btn btn-secondary" href="artist.html" style="margin-left:12px">Artist Page</a>
+          </p>
+        </div>
+      </section>
+
+      <section class="form-section" aria-labelledby="form-heading">
+        <div class="container">
+          <h2 id="form-heading" class="section-title">Create or Edit Account</h2>
+          <div class="form-card">
+            <form id="artist-form" novalidate>
+              <input type="hidden" id="artist-id" />
+              <div class="form-grid">
+                <div class="form-row">
+                  <label class="label" for="name">Full Name *</label>
+                  <input id="name" class="input" type="text" required placeholder="e.g., Aunty Margaret Wirrinyga" />
+                </div>
+                <div class="form-row">
+                  <label class="label" for="email">Contact Email *</label>
+                  <input id="email" class="input" type="email" required placeholder="name@example.com" />
+                </div>
+                <div class="form-row">
+                  <label class="label" for="role">Role *</label>
+                  <select id="role" class="select" required>
+                    <option value="artist">Artist</option>
+                    <option value="user" selected>User</option>
+                  </select>
+                </div>
+                <div class="form-row">
+                  <label class="label" for="region">Region / State</label>
+                  <select id="region" class="select">
+                    <option value="">Select region</option>
+                    <option value="NSW">NSW</option><option value="VIC">VIC</option>
+                    <option value="QLD">QLD</option><option value="SA">SA</option>
+                    <option value="WA">WA</option><option value="NT">NT</option>
+                    <option value="TAS">TAS</option><option value="ACT">ACT</option>
+                  </select>
+                </div>
+                <div class="form-row">
+                  <label class="label" for="nation">Nation / Language Group</label>
+                  <input id="nation" class="input" type="text" placeholder="e.g., Kaurna, Yolŋu, ..." />
+                </div>
+                <div class="form-row full">
+                  <label class="label" for="imageUrl">Profile Image URL</label>
+                  <input id="imageUrl" class="input" type="url" placeholder="https://.../photo.jpg (optional)" />
+                </div>
+                <div class="form-row full">
+                  <label class="label" for="bio">Bio (optional)</label>
+                  <textarea id="bio" class="textarea" placeholder="Short biography, statement, or notes..."></textarea>
+                </div>
+              </div>
+
+              <div class="form-actions">
+                <button class="btn btn-primary" type="submit" id="saveBtn">Submit</button>
+                <button class="btn btn-secondary" type="button" id="resetBtn">Reset</button>
+                <a class="btn btn-secondary" href="artwork-submit.html" id="submitArtworkBtn">Artwork Information Submission Form</a>
+        
+              </div>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section class="list-section" aria-labelledby="list-heading">
+        <div class="container">
+          <h2 id="list-heading" class="section-title">Accounts</h2>
+          <div class="list-grid" id="artist-list" role="list"></div>
+        </div>
+      </section>
+
+      <dialog id="viewDialog" aria-labelledby="viewTitle" aria-modal="true">
+        <h3 id="viewTitle" class="page-title" style="font-size:var(--font-size-2xl);margin-bottom:var(--space-md)">Account</h3>
+        <div id="viewBody" class="page-description"></div>
+        <div class="form-actions" style="margin-top:var(--space-xl)">
+          <button class="btn btn-secondary" onclick="document.getElementById('viewDialog').close()">Close</button>
+        </div>
+      </dialog>
+    </main>
+
+    <footer class="footer" role="contentinfo">
+      <div class="container">
+        <div class="footer-bottom">
+          <p class="footer-copyright">© Indigenous Art Atlas</p>
+        </div>
+      </div>
+    </footer>
+
+    <script src="register.js" defer></script>
+  </body>
+</html>

--- a/src/cycle2/register.js
+++ b/src/cycle2/register.js
@@ -1,0 +1,274 @@
+/* Account Register — Vanilla JS, localStorage only */
+
+const STORE_KEY = "IAA_accounts_v1"; // accounts (user or artist)
+
+const form = document.getElementById("artist-form");
+const idInput = document.getElementById("artist-id");
+const nameInput = document.getElementById("name");
+const nationInput = document.getElementById("nation");
+const regionSelect = document.getElementById("region");
+const emailInput = document.getElementById("email");
+const imageInput = document.getElementById("imageUrl");
+const bioInput = document.getElementById("bio");
+const roleSelect = document.getElementById("role");
+
+const listEl = document.getElementById("artist-list");
+const viewDialog = document.getElementById("viewDialog");
+const viewBody = document.getElementById("viewBody");
+
+const resetBtn = document.getElementById("resetBtn");
+const exportBtn = document.getElementById("exportBtn");
+const importFile = document.getElementById("importFile");
+const submitArtworkBtn = document.getElementById("submitArtworkBtn");
+
+function loadAccounts() {
+  try { return JSON.parse(localStorage.getItem(STORE_KEY)) || []; }
+  catch { return []; }
+}
+
+function saveAccounts(arr) { localStorage.setItem(STORE_KEY, JSON.stringify(arr)); }
+
+function uid() { return "u_" + Math.random().toString(36).slice(2) + Date.now().toString(36); }
+
+
+// Derive a human-friendly label from a detail page URL (e.g., detail.html?id=sorry -> "Sorry")
+function prettyLabelFromArtworkUrl(u){
+  try{
+    const url = new URL(u, location.href);
+    let slug = url.searchParams.get("id");
+    if(!slug){
+      const last = url.pathname.split("/").filter(Boolean).pop() || "";
+      slug = last.replace(/\.[a-z0-9]+$/i, "");
+    }
+    if(!slug) return "Artwork";
+    let words = slug
+      .replace(/[_\-]+/g, " ")
+      .replace(/([a-z])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(" ")
+      .filter(Boolean)
+      .map(w => w.length ? w[0].toUpperCase() + w.slice(1) : w);
+    const ACR = new Set(["nsw","vic","qld","sa","wa","nt","tas","act","tv"]);
+    words = words.map(w => ACR.has(w.toLowerCase()) ? w.toUpperCase() : w);
+    return words.join(" ");
+  }catch(e){ return "Artwork"; }
+}
+/* ----- Validations ----- */
+function isValidEmail(v){ return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v); }
+function isValidUrl(v){ try { new URL(v); return true; } catch { return false; } }
+function applyNameValidity(){
+  const v = nameInput.value.trim();
+  if (!v) nameInput.setCustomValidity("Please enter the artist name.");
+  else nameInput.setCustomValidity("");
+}
+function applyEmailValidity(){
+  const v = emailInput.value.trim();
+  if (!v) emailInput.setCustomValidity("Inappropriate email format!");
+  else if (!isValidEmail(v)) emailInput.setCustomValidity("Inappropriate email format!");
+  else emailInput.setCustomValidity("");
+}
+function applyUrlValidity(){
+  const i = imageInput.value.trim();
+  if (i && !isValidUrl(i)) imageInput.setCustomValidity("Inappropriate URL format!"); else imageInput.setCustomValidity("");
+}
+nameInput.addEventListener("input", applyNameValidity);
+nameInput.addEventListener("blur", ()=>{applyNameValidity(); if(!nameInput.checkValidity()) nameInput.reportValidity();});
+emailInput.addEventListener("input", applyEmailValidity);
+emailInput.addEventListener("blur", ()=>{applyEmailValidity(); if(!emailInput.checkValidity()) emailInput.reportValidity();});
+imageInput.addEventListener("input", applyUrlValidity);
+imageInput.addEventListener("blur", ()=>{applyUrlValidity(); if(!imageInput.checkValidity()) imageInput.reportValidity();});
+
+function renderList() {
+  const accounts = loadAccounts();
+  listEl.innerHTML = "";
+  if (accounts.length === 0) {
+    listEl.innerHTML = `<div style="grid-column:1/-1;text-align:center;color:var(--muted);padding:var(--space-2xl)">
+      No accounts yet. Use the form above to add one.
+    </div>`;
+    return;
+  }
+
+  accounts.forEach(acc => {
+    const card = document.createElement("div");
+    card.className = "artist-card";
+    card.setAttribute("role", "listitem");
+
+    const cover = document.createElement("img");
+    cover.className = "artist-cover";
+    cover.alt = `${acc.name} profile image`;
+    cover.loading = "lazy";
+    cover.src = acc.imageUrl || "assets/img/user-avatar.png";
+    cover.onerror = () => { cover.src = "assets/img/user-avatar.png"; };
+
+    const statusClass = acc.status === "approved" ? "status-approved" : "status-pending";
+    const statusText = acc.status === "approved" ? "Approved" : "Pending Approval";
+
+    const body = document.createElement("div");
+    body.className = "artist-content";
+    body.innerHTML = `
+      <h3 class="artist-title">${acc.name}</h3>
+      <p class="artist-sub">${acc.role ? acc.role.toUpperCase() : "USER"} 
+        <span class="status-badge ${statusClass}">${statusText}</span>
+      </p>
+      <p class="subtle">${acc.email ? acc.email : ""}</p>
+      ${acc.bio?`<p style="margin-top:var(--space-sm);color:var(--muted);line-height:1.6">${escapeHtml(acc.bio).slice(0,180)}${acc.bio.length>180?"…":""}</p>`:""}
+      <div style="margin-top:var(--space-sm)">
+        ${acc.nation?`<span class="tag">${escapeHtml(acc.nation)}</span>`:""}
+        ${acc.region?`<span class="tag">${escapeHtml(acc.region)}</span>`:""}
+      </div>
+      ${acc.role === "artist" && acc.artworks && acc.artworks.length ? `
+        <div style="margin-top:var(--space-md)">
+          <strong>Published Artworks:</strong>
+          <div class="links-list">${acc.artworks.map(u=>`<a class="footer-link" href="${u}" target="_blank" rel="noopener">${prettyLabelFromArtworkUrl(u)}</a>`).join("")}</div>
+        </div>` : ""}
+      <div class="card-actions">
+        <button class="btn btn-secondary" type="button" aria-label="View" data-act="view">View</button>
+        <button class="btn btn-secondary" type="button" aria-label="Edit" data-act="edit">Edit</button>
+        <button class="btn btn-report"   type="button" aria-label="Delete" data-act="del">Delete</button>
+        ${acc.role==="artist" && acc.status==="approved" ? `<a class="btn btn-secondary" href="artwork-submit.html">Submit Artwork</a>` : ""}
+      </div>
+    `;
+
+    body.addEventListener("click", (e) => {
+      const btn = e.target.closest("button,a.btn");
+      if (!btn) return;
+      const act = btn.dataset.act;
+      if (act === "view")      openView(acc);
+      else if (act === "edit") fillForm(acc);
+      else if (act === "del")  removeAccount(acc.id);
+    });
+
+    card.appendChild(cover);
+    card.appendChild(body);
+    listEl.appendChild(card);
+  });
+}
+
+function escapeHtml(str) {
+  return String(str).replace(/[&<>\"']/g, s => ({
+    "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"
+  }[s]));
+}
+
+function openView(a) {
+  const statusClass = a.status === "approved" ? "status-approved" : "status-pending";
+  const statusText = a.status === "approved" ? "Approved" : "Pending Approval";
+  const artLinks = (a.role==="artist" && a.artworks && a.artworks.length)
+    ? `<div style="margin-top:var(--space-md)"><strong>Published Artworks</strong><div class="links-list">${a.artworks.map(u=>`<a class="footer-link" href="${u}" target="_blank" rel="noopener">${prettyLabelFromArtworkUrl(u)}</a>`).join("")}</div></div>`
+    : "";
+  viewBody.innerHTML = `
+    <div style="display:grid;grid-template-columns:160px 1fr;gap:var(--space-lg)">
+      <img src="${a.imageUrl || "assets/img/user-avatar.png"}" alt="${a.name}" style="width:160px;height:160px;object-fit:cover;border-radius:var(--border-radius);border:1px solid var(--elev-2)"/>
+      <div>
+        <p><strong>Name:</strong> ${a.name}</p>
+        <p><strong>Role:</strong> ${a.role ? a.role.toUpperCase():"USER"} <span class="status-badge ${statusClass}">${statusText}</span></p>
+        ${a.nation?`<p><strong>Nation/Language:</strong> ${a.nation}</p>`:""}
+        ${a.region?`<p><strong>Region:</strong> ${a.region}</p>`:""}
+        ${a.email?`<p><strong>Email:</strong> ${a.email}</p>`:""}
+        ${a.bio?`<div style="margin-top:var(--space-md)"><strong>Bio</strong><p style="color:var(--muted);line-height:1.7;margin-top:var(--space-xs)">${escapeHtml(a.bio)}</p></div>`:""}
+        ${artLinks}
+      </div>
+    </div>
+  `;
+  if (typeof viewDialog.showModal === "function") viewDialog.showModal(); else alert("Dialog: " + a.name);
+}
+
+function fillForm(a) {
+  idInput.value = a.id;
+  nameInput.value = a.name || "";
+  emailInput.value = a.email || "";
+  roleSelect.value = a.role || "user";
+  regionSelect.value = a.region || "";
+  nationInput.value = a.nation || "";
+  imageInput.value = a.imageUrl || "";
+  bioInput.value = a.bio || "";
+  nameInput.focus();
+  document.getElementById("saveBtn").textContent = "Update";
+}
+
+function removeAccount(id) {
+  if (!confirm("Delete this account?")) return;
+  const accounts = loadAccounts().filter(a => a.id !== id);
+  saveAccounts(accounts);
+  renderList();
+  form.reset();
+  idInput.value = "";
+  document.getElementById("saveBtn").textContent = "Save";
+}
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  applyNameValidity(); applyEmailValidity(); applyUrlValidity();
+  if (!form.checkValidity()) { form.reportValidity(); return; }
+
+  const acc = {
+    id: idInput.value || uid(),
+    name: nameInput.value.trim(),
+    email: emailInput.value.trim(),
+    role: roleSelect.value,
+    region: regionSelect.value,
+    nation: nationInput.value.trim(),
+    imageUrl: imageInput.value.trim(),
+    bio: bioInput.value.trim(),
+    status: "pending",      // Admin will set to "approved" on review
+    artworks: []            // Admin can add published artwork links later
+  };
+
+  const list = loadAccounts();
+  const idx = list.findIndex(a => a.id === acc.id);
+  if (idx >= 0) {
+    // Preserve server/admin-managed fields if present
+    const prev = list[idx];
+    acc.status = prev.status || acc.status;
+    acc.artworks = Array.isArray(prev.artworks) ? prev.artworks : [];
+    list[idx] = acc;
+  } else {
+    list.push(acc);
+  }
+  saveAccounts(list);
+
+  renderList();
+  form.reset();
+  idInput.value = "";
+  document.getElementById("saveBtn").textContent = "Save";
+});
+
+resetBtn.addEventListener("click", () => {
+  form.reset(); idInput.value = "";
+  document.getElementById("saveBtn").textContent = "Save";
+});
+
+exportBtn && exportBtn.addEventListener("click", () => {
+  const data = JSON.stringify(loadAccounts(), null, 2);
+  const blob = new Blob([data], {type: "application/json"});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = "accounts.json"; a.click();
+  URL.revokeObjectURL(url);
+});
+
+importFile && importFile.addEventListener("change", async (e) => {
+  const file = e.target.files?.[0]; if (!file) return;
+  const text = await file.text();
+  try {
+    const arr = JSON.parse(text);
+    if (!Array.isArray(arr)) throw new Error("Bad JSON");
+    saveAccounts(arr); renderList();
+  } catch {
+    alert("Invalid JSON file.");
+  } finally {
+    importFile.value = "";
+  }
+});
+
+/* Disable top-level submission button when not eligible (not artist or not approved) */
+function updateSubmitBtnState(){
+  const id = idInput.value;
+  const list = loadAccounts();
+  const found = list.find(a=>a.id===id);
+  const eligible = found && found.role==="artist" && found.status==="approved";
+  submitArtworkBtn.classList.toggle("btn-disabled", !eligible);
+  submitArtworkBtn.setAttribute("aria-disabled", String(!eligible));
+}
+form.addEventListener("input", updateSubmitBtnState);
+document.addEventListener("DOMContentLoaded", () => { renderList(); updateSubmitBtnState(); });

--- a/src/cycle2/search.html
+++ b/src/cycle2/search.html
@@ -38,7 +38,7 @@
               <li><a href="homePage/index.html#map-section" class="nav-link">Map</a></li>
               <li><a href="search.html" class="nav-link nav-active">Search</a></li>
               <li><a href="about.html" class="nav-link">About Us</a></li>
-              <li><a href="#" class="nav-link nav-disabled" title="Coming soon">Register</a></li>
+              <li><a href="register.html" class="nav-link">Register</a></li>
             </ul>
             <div class="user-avatar">
               <div class="avatar-container">

--- a/src/cycle2/search.js
+++ b/src/cycle2/search.js
@@ -3,6 +3,9 @@ const artEntries = (window.AppData && window.AppData.artEntries) || [];
 
 // ===== GLOBAL VARIABLES =====
 let filteredEntries = [...artEntries];
+// Auto open first result once if requested via URL
+window.__autoOpenFirst = false;
+// __AUTO_OPEN_FIRST__ marker
 
 // ===== DOM ELEMENTS =====
 const searchInput = document.getElementById("search-input");
@@ -79,6 +82,15 @@ function renderSearchResults(entries) {
     card.style.cursor = 'pointer';
     resultsGrid.appendChild(card);
   });
+
+  // Auto open first result once if requested
+  if (window.__autoOpenFirst && entries.length > 0) {
+    window.__autoOpenFirst = false;
+    const first = entries[0];
+    try {
+      window.location.href = `${window.Utils.page('detail.html')}?id=${first.id}`;
+    } catch (_) {}
+  }
 }
 
 // ===== FILTERING AND SORTING =====
@@ -200,6 +212,22 @@ document.addEventListener("DOMContentLoaded", function () {
   if (searchBtn) {
     searchBtn.addEventListener("click", applyFilters);
   }
+
+  
+  // Handle deep link: ?artist=<name>&autoview=1
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    const artistParam = sp.get('artist');
+    const autoview = sp.get('autoview');
+    if (artistParam) {
+      if (searchInput) searchInput.value = artistParam;
+      applyFilters();
+      if (autoview === '1' || autoview === 'true') {
+        window.__autoOpenFirst = true;
+        // applyFilters already called; renderSearchResults will redirect
+      }
+    }
+  } catch (_) {}
 
   console.log("Search page initialized successfully");
   console.log(`Loaded ${artEntries.length} artwork entries for search`);


### PR DESCRIPTION
feat(register, artist, detail): show artist’s published artwork links; rename Save→Submit; remove Import/Export; fix Register nav on detail page

### What’s changed
- Register page
  - Added **Published Artwork Links** (multi-line). Links render in the profile card so artists can directly access their own works from the Register page.
  - Link labels auto-derived from URL (e.g. `detail.html?id=vincent-namatjira-stand-strong` → “Vincent Namatjira Stand Strong”), instead of the generic “Artwork”.
  - Renamed **Save → Submit**; kept functionality/IDs the same.
  - Removed **Export** & **Import** buttons (and hidden import input).  
    - Guarded related code paths in `register.js` to avoid errors when controls are missing.
  - Kept **Reset** and **Artwork Information Submission Form** button.
  - Kept English-only custom validations/messages (e.g., *“Inappropriate email format!”*, *“Please enter the artist name.”*).
  - Website field was removed earlier and remains removed per feedback.

- Artist page
  - Kept the new **Artist Page** flow (select account → Open/Copy Share Link).
  - **Name-search jump** entry is hidden as requested (no public search-by-name shortcut).

- Detail page
  - Fixed the top-right **Register** nav link (was disabled with `href="#"`); now points to `register.html`.

- Artwork submission form
  - (Unchanged in this diff) Still supports constrained dropdowns (Art Type/Period/Region), Sensitive flag with address disable, and the extra Artwork Image field.

### Files touched
- `register.html`
- `register.js`
- `artist.html`
- `detail.html`

### Why
- Match Cycle 2 front-end scope: artists see and open **their own** published artworks without a backend, and UI wording/style aligns with the existing site.
- Remove non-essential controls (Export/Import) to simplify the flow.
- Fix broken navigation on detail pages.

### How to test
1. Open `register.html`.
   - Fill profile fields and add one or more lines in **Published Artwork Links** (e.g. `detail.html?id=sorry`).
   - Click **Submit** → profile card should show the links with **readable titles**, each opening in a new tab.
   - Click **Reset** → form clears.
   - Ensure Export/Import buttons are **absent**.
2. Open `artist.html`.
   - Confirm the **name-search** shortcut is **hidden**.
   - Use the account selector; **Open** should deep-link to Search with the artist query and open the first result’s **View Details** automatically (when available).  
     **Copy Share Link** should copy the same deep link.
3. Open any artwork **detail page** (e.g., from Search).
   - Top-right **Register** is clickable and routes to `register.html`.

### Notes / Future
- When backend is ready, replace localStorage reads/writes with `/auth/me` and `/users/me` APIs; field `artworks: string[]` should be persisted server-side.
- If a canonical `id → title` map is provided, replace URL-derived labels with real titles for perfect parity.

### Checklist
- [x] No console errors in modern browsers
- [x] Matches dark theme & existing typography/styles
- [x] Header **Register** link works on detail pages
- [x] “Published Artwork Links” show human-readable titles
- [x] No **Export/Import** controls on Register page
